### PR TITLE
refactor: 리뷰 예외처리 수정, 이벤트 조회 도메인 수정, 점포 도메인명 수정 #57

### DIFF
--- a/src/main/java/org/example/luckyburger/domain/event/controller/EventAdminController.java
+++ b/src/main/java/org/example/luckyburger/domain/event/controller/EventAdminController.java
@@ -2,19 +2,25 @@ package org.example.luckyburger.domain.event.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.luckyburger.common.dto.response.ApiPageResponse;
 import org.example.luckyburger.common.dto.response.ApiResponse;
 import org.example.luckyburger.domain.auth.enums.AccountRole;
 import org.example.luckyburger.domain.event.dto.request.EventCreateRequest;
 import org.example.luckyburger.domain.event.dto.response.EventResponse;
 import org.example.luckyburger.domain.event.service.EventAdminService;
+import org.example.luckyburger.domain.event.service.EventService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventAdminController {
 
     private final EventAdminService eventAdminService;
+    private final EventService eventService;
 
     @PostMapping("/v1/admin/events")
     public ResponseEntity<ApiResponse<EventResponse>> createEvent(
@@ -44,5 +51,15 @@ public class EventAdminController {
     public ResponseEntity<ApiResponse<Void>> deleteEvent(@PathVariable Long eventId) {
         eventAdminService.deleteEvent(eventId);
         return ApiResponse.noContent();
+    }
+
+    @GetMapping("/v1/admin/events/all")
+    public ResponseEntity<ApiPageResponse<EventResponse>> getAllEvent(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        return ApiPageResponse.success(eventService.getAllEventResponse(pageable));
     }
 }

--- a/src/main/java/org/example/luckyburger/domain/event/controller/EventController.java
+++ b/src/main/java/org/example/luckyburger/domain/event/controller/EventController.java
@@ -26,16 +26,6 @@ public class EventController {
         return ApiResponse.success(eventService.getEventResponse(eventId));
     }
 
-    @GetMapping("/v1/events/all")
-    public ResponseEntity<ApiPageResponse<EventResponse>> getAllEvent(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
-
-        return ApiPageResponse.success(eventService.getAllEventResponse(pageable));
-    }
-
     @GetMapping("/v1/events")
     public ResponseEntity<ApiPageResponse<EventResponse>> getAllEventByNotDeleted(
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/org/example/luckyburger/domain/review/service/ReviewUserService.java
+++ b/src/main/java/org/example/luckyburger/domain/review/service/ReviewUserService.java
@@ -9,6 +9,7 @@ import org.example.luckyburger.domain.order.service.OrderEntityFinder;
 import org.example.luckyburger.domain.review.dto.request.ReviewRequest;
 import org.example.luckyburger.domain.review.dto.response.ReviewResponse;
 import org.example.luckyburger.domain.review.entity.Review;
+import org.example.luckyburger.domain.review.exception.OrderUnauthorizedException;
 import org.example.luckyburger.domain.review.exception.ReviewUnauthorizedException;
 import org.example.luckyburger.domain.review.repository.ReviewRepository;
 import org.example.luckyburger.domain.user.entity.User;
@@ -33,7 +34,7 @@ public class ReviewUserService {
         Order order = orderEntityFinder.getOrderById(orderId);
 
         if (!order.getUser().getAccount().getId().equals(authUser.getAccount().getId())) {
-            throw new ReviewUnauthorizedException();
+            throw new OrderUnauthorizedException();
         }
 
         Review review = Review.of(

--- a/src/main/java/org/example/luckyburger/domain/shop/controller/ShopController.java
+++ b/src/main/java/org/example/luckyburger/domain/shop/controller/ShopController.java
@@ -9,7 +9,11 @@ import org.example.luckyburger.domain.shop.service.ShopService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
@@ -29,7 +33,7 @@ public class ShopController {
         return ApiPageResponse.success(shopService.searchShopByName(shopName, pageable));
     }
 
-    @GetMapping("/v1/shops/{shopId}/shop-menus")
+    @GetMapping("/v1/shops/{shopId}/shopMenus")
     public ResponseEntity<ApiPageResponse<ShopMenuResponse>> getAllShopMenu(
             @PathVariable Long shopId,
             @RequestParam(defaultValue = "0") int page,
@@ -40,7 +44,7 @@ public class ShopController {
         return ApiPageResponse.success(shopService.getAllShopMenuByShopIdResponse(shopId, pageable));
     }
 
-    @GetMapping("/v1/shops/{shopId}/shop-menus/{shopMenuId}")
+    @GetMapping("/v1/shops/{shopId}/shopMenus/{shopMenuId}")
     public ResponseEntity<ApiResponse<ShopMenuResponse>> getMenuDetail(
             @PathVariable Long shopId,
             @PathVariable Long shopMenuId


### PR DESCRIPTION
## 🔗 **연관된 이슈**

Related to: #57 

## 📝 **작업 내용**

- 리뷰 예외처리 수정 (주문을 못찾았을때)
- 점포 도메인명 스네이크 케이스를 카멜 케이스로
- 이벤트 전체 조회 시 삭제된 내용을 보여주는 부분은 Admin으로 이동