### PR TITLE
feat: 모니터링 서비스 연결 #63

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // [actuator]
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // [prometheus]
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // [OpenSource]
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-lifecycle'
+    ports:
+      - '9090:9090'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - '3000:3000'
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on: [ prometheus ]
+    restart: unless-stopped

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'local-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ] # EC2 배포시 해당 IP로 변경
+        labels:
+          env: 'local'
+          app: 'order-service'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,7 +31,7 @@ jwt:
       - /api/v1/coupons/**
       - /api/v1/shops/**
       - /api/v1/events/**
-      - /api/v1/actuator/health
+      - /actuator/health
       - /actuator/prometheus
 
   token:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,12 @@ spring:
         show_sql: true
         format_sql: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+
 jwt:
   secret:
     aesKey: ${AES_KEY}
@@ -25,6 +31,9 @@ jwt:
       - /api/v1/coupons/**
       - /api/v1/shops/**
       - /api/v1/events/**
+      - /api/v1/actuator/health
+      - /actuator/prometheus
+
   token:
     prefix: 'Bearer '
     expiration: ${JWT_EXPIRATION}


### PR DESCRIPTION
## 🔗 **연관된 이슈**

Related to: #63 

## 📝 **작업 내용**

- prometheus 설정
- docker-compose 설정

## 실행 방법
1. docker desktop을 실행한다 (실행 전 반드시 한번은 켜야 함)
2. 인텔리제이 terminal에서 아래 명령어 실행
  - `docker compose up -d`
3. LuckyBurger 어플리케이션 실행
4. 프로메테우스 동작 확인
  - `http://localhost:9090` -> Status -> Targets HealthCheck 에서 local-app이 `UP`이면 성공
5. 그라파나 연결
  -  `http://localhost:3000` 접속
  - 기본 계정 로그인
    - ID: admin, PW: admin
  - Prometheus 데이터 소스 등록
    - 사이드바 -> Connections -> Data Sources -> Add Data Source (Prometheus 선택)
    - -> url: `http://prometheus:9090` -> 맨 하단 Save&Test
  - DashBoard 만들기
    - DashBoard -> Import -> ID `4701` 입력 (기본 Spring Boot Stats) -> Prometheus 데이터소스 선택 -> Import

참고 사항
- 로컬 -> EC2로 변경 시 `prometheus.yml`의 targets만 게이트웨이/프라이빗IP로 변경하면 됨
- 대시보드 상단에서 모니터링 시간 변경 가능 (기본 24시간)
- 추천 대시보드 (쿼리 수동 입력)
  - 전체 RPS (요청량 변화 확인)
    - `sum(rate(http_server_requests_seconds_count[1m]))`
  - 에러율 (5xx) (오류 비율 확인)
    - `sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))`
  - P95 응답시간 (응답 지연 감지)
    - `histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket[5m])))`
  - HikariCP 사용률 (DB 커넥션 풀 상태)
    - `hikaricp_connections_active / hikaricp_connections_max`
  - JVM Heap (메모리 모니터링)
    - `jvm_memory_used_bytes{area="heap"}`