### PR TITLE
Add LuckyBurger7 frontend application

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <!-- TOC -->
 
 - [LuckyBurger7](#LuckyBurger7)
+  - [LuckyBurger7 프론트엔드](#luckyburger7-프론트엔드)
   - [1. 프로젝트 개요](#1-프로젝트-개요)
   - [2. ERD](#2-erd)
   - [3. 기능 설계](#3-기능-설계)
@@ -25,6 +26,22 @@
   - [10. 팀원](#10-팀원)
 
 <!-- /TOC -->
+
+## LuckyBurger7 프론트엔드
+
+- `frontend/` 디렉터리에 Vite + React(TypeScript) 기반의 UI 레이어를 추가했습니다.
+- 설치 및 실행
+  1. `cd frontend`
+  2. `npm install`
+  3. `npm run dev`
+- 환경 변수
+  - `VITE_API_URL`: LuckyBurger7 백엔드 API 엔드포인트 (기본값 `http://localhost:8080/api`)
+  - `VITE_API_PROXY`: 개발 서버 프록시 대상 (선택 사항)
+- 주요 화면
+  - **홈**: 메뉴/매장/쿠폰 요약과 하이라이트 카드
+  - **메뉴/매장/쿠폰**: `/api/v1/menus`, `/api/v1/shops/search`, `/api/v1/coupons` 연동 검색/페이지네이션 UI
+  - **장바구니**: `/api/v1/user/carts`, `/api/v2/user/carts` API 호출, 인증 토큰 기반 CRUD 폼
+  - **관리자 대시보드**: `/api/v1/admin/**` 통계 API 시각화 (ADMIN 권한 로그인 필요)
 
 ## 1. 프로젝트 개요
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.DS_Store
+.env
+.env.*
+.vite

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lucky Burger 7</title>
+    <meta
+      name="description"
+      content="LuckyBurger7 백엔드 API를 위한 프론트엔드 대시보드"
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "luckyburger7-front",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.29.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,29 @@
+import { Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import HomePage from './pages/Home';
+import MenusPage from './pages/Menus';
+import ShopsPage from './pages/Shops';
+import CouponsPage from './pages/Coupons';
+import CartPage from './pages/Cart';
+import LoginPage from './pages/Login';
+import AdminDashboardPage from './pages/AdminDashboard';
+import NotFoundPage from './pages/NotFound';
+
+function App() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/menus" element={<MenusPage />} />
+        <Route path="/shops" element={<ShopsPage />} />
+        <Route path="/coupons" element={<CouponsPage />} />
+        <Route path="/cart" element={<CartPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/admin" element={<AdminDashboardPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </Layout>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,117 @@
+export const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8080/api';
+
+let authToken: string | null = null;
+
+export function setAuthToken(token: string | null) {
+  authToken = token;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+}
+
+export interface ApiPageResponse<T> {
+  data: T[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+}
+
+export interface ApiErrorResponse {
+  error: {
+    status: string;
+    code: string;
+    message: string;
+    requestUrl: string;
+    timestamp: string;
+  };
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+
+  if (!response.ok) {
+    if (!text) {
+      throw new Error(response.statusText);
+    }
+    try {
+      const json = JSON.parse(text) as ApiErrorResponse;
+      const errorMessage = json.error?.message ?? response.statusText;
+      throw new Error(errorMessage);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(response.statusText);
+      }
+      throw error;
+    }
+  }
+
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text) as T;
+}
+
+function buildHeaders(init?: RequestInit): HeadersInit {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('Content-Type') && init?.body) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (authToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${authToken}`);
+  }
+  return headers;
+}
+
+export async function apiGet<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    method: 'GET',
+    headers: buildHeaders(init)
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiPost<T>(path: string, body?: unknown, init?: RequestInit): Promise<T> {
+  const payload = body ? JSON.stringify(body) : init?.body;
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    method: 'POST',
+    headers: buildHeaders({ ...init, body: payload }),
+    body: payload
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiPut<T>(path: string, body?: unknown, init?: RequestInit): Promise<T> {
+  const payload = body ? JSON.stringify(body) : init?.body;
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    method: 'PUT',
+    headers: buildHeaders({ ...init, body: payload }),
+    body: payload
+  });
+  return handleResponse<T>(response);
+}
+
+export async function apiDelete<T>(path: string, body?: unknown, init?: RequestInit): Promise<T> {
+  const payload = body ? JSON.stringify(body) : init?.body;
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    method: 'DELETE',
+    headers: buildHeaders({ ...init, body: payload }),
+    body: payload
+  });
+  return handleResponse<T>(response);
+}
+
+export async function getData<T>(path: string): Promise<T> {
+  const response = await apiGet<ApiResponse<T>>(path);
+  return response.data;
+}
+
+export async function getPagedData<T>(path: string): Promise<ApiPageResponse<T>> {
+  return apiGet<ApiPageResponse<T>>(path);
+}

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,0 +1,91 @@
+import {
+  AdminDashboardResponse,
+  CartResponse,
+  CouponResponse,
+  MenuResponse,
+  MenuTotalSalesResponse,
+  MonthTotalSalesResponse,
+  ShopMenuResponse,
+  ShopResponse,
+  ShopTotalSalesResponse,
+  TokenResponse
+} from './types';
+import { ApiResponse, getData, getPagedData, apiPost, apiDelete, apiPut } from './client';
+
+export function fetchMenus({ page = 0, size = 12, keyword }: { page?: number; size?: number; keyword?: string }) {
+  const basePath = keyword ? `/v1/menus/search?menuName=${encodeURIComponent(keyword)}` : '/v1/menus';
+  return getPagedData<MenuResponse>(`${basePath}${basePath.includes('?') ? '&' : '?'}page=${page}&size=${size}`);
+}
+
+export function fetchMenuDetail(menuId: number) {
+  return getData<MenuResponse>(`/v1/menus/${menuId}`);
+}
+
+export function fetchShops({ page = 0, size = 12, keyword }: { page?: number; size?: number; keyword?: string }) {
+  const query = new URLSearchParams();
+  if (keyword) {
+    query.set('shopName', keyword);
+  }
+  query.set('page', String(page));
+  query.set('size', String(size));
+  return getPagedData<ShopResponse>(`/v1/shops/search?${query.toString()}`);
+}
+
+export function fetchShopMenus(shopId: number, page = 0, size = 12) {
+  return getPagedData<ShopMenuResponse>(`/v1/shops/${shopId}/shopMenus?page=${page}&size=${size}`);
+}
+
+export function fetchCoupons(page = 0, size = 12) {
+  return getPagedData<CouponResponse>(`/v1/coupons?page=${page}&size=${size}`);
+}
+
+export function fetchCart(useCache = false) {
+  return getData<CartResponse>(useCache ? '/v2/user/carts' : '/v1/user/carts');
+}
+
+export function addCartMenu(shopMenuId: number, useCache = false) {
+  return apiPost<ApiResponse<void>>(useCache ? '/v2/user/carts' : '/v1/user/carts', {
+    shopMenuId
+  });
+}
+
+export function updateCartMenu(shopMenuId: number, quantity: number, useCache = false) {
+  return apiPut<ApiResponse<CartResponse>>(useCache ? '/v2/user/carts' : '/v1/user/carts', {
+    shopMenuId,
+    quantity
+  });
+}
+
+export function deleteCartMenu(shopMenuId: number, useCache = false) {
+  return apiDelete<ApiResponse<CartResponse>>(useCache ? '/v2/user/carts' : '/v1/user/carts', {
+    shopMenuId
+  });
+}
+
+export function authenticate(loginForm: { email: string; password: string }) {
+  return apiPost<ApiResponse<TokenResponse>>('/v1/login', loginForm).then((response) => response.data);
+}
+
+export function fetchAdminDashboard() {
+  return getData<AdminDashboardResponse>('/v1/admin/dashboard');
+}
+
+export function fetchMonthlySales() {
+  return getData<MonthTotalSalesResponse[]>('/v1/admin/statistics/sales/monthly');
+}
+
+export function fetchTopShops() {
+  return getData<ShopTotalSalesResponse[]>('/v1/admin/statistics/sales/shops/top10');
+}
+
+export function fetchBottomShops() {
+  return getData<ShopTotalSalesResponse[]>('/v1/admin/statistics/sales/shops/bottom10');
+}
+
+export function fetchBurgerSales() {
+  return getData<MenuTotalSalesResponse[]>('/v1/admin/statistics/sales/menus/burger');
+}
+
+export function fetchSideSales() {
+  return getData<MenuTotalSalesResponse[]>('/v1/admin/statistics/sales/menus/side');
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,83 @@
+export type MenuCategory = 'HAMBURGER' | 'SIDE' | 'DRINK';
+
+export interface MenuResponse {
+  menuId: number;
+  name: string;
+  menuCategory: MenuCategory;
+  price: number;
+}
+
+export type BusinessStatus = 'OPEN' | 'BREAK' | 'CLOSED';
+
+export interface ShopResponse {
+  shopId: number;
+  name: string;
+  businessStatus: BusinessStatus;
+  address: string;
+  street: string;
+}
+
+export type ShopMenuStatus = 'ON_SALE' | 'OUT_OF_STOCK' | 'DEACTIVATE';
+
+export interface ShopMenuResponse {
+  shopMenuId: number;
+  name: string;
+  menuCategory: MenuCategory;
+  price: number;
+  menuStatus: ShopMenuStatus;
+}
+
+export type CouponType = 'RATIO' | 'FIXED';
+
+export interface CouponResponse {
+  couponId: number;
+  name: string;
+  discount: number;
+  count: number;
+  expirationDate: string;
+  couponType: CouponType;
+  createAt: string;
+}
+
+export interface CartMenuResponse {
+  shopMenuId: number;
+  menuName: string;
+  shopName: string;
+  quantity: number;
+  price: number;
+}
+
+export interface CartResponse {
+  cartId: number;
+  cartMenus: CartMenuResponse[];
+  totalPrice: number;
+}
+
+export interface TokenResponse {
+  accessToken: string;
+}
+
+export interface AdminDashboardResponse {
+  totalShopCount: number;
+  totalOrderCount: number;
+  activeCoupon: number;
+  totalSales: number;
+}
+
+export interface MonthTotalSalesResponse {
+  year: number;
+  month: number;
+  totalSales: number;
+}
+
+export interface ShopTotalSalesResponse {
+  shopId: number;
+  shopName: string;
+  totalSales: number;
+}
+
+export interface MenuTotalSalesResponse {
+  menuId: number;
+  menuName: string;
+  totalSales: number;
+}

--- a/frontend/src/components/DataCard.tsx
+++ b/frontend/src/components/DataCard.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+interface DataCardProps {
+  title: string;
+  value: ReactNode;
+  subtitle?: string;
+  accent?: ReactNode;
+}
+
+function DataCard({ title, value, subtitle, accent }: DataCardProps) {
+  return (
+    <div className="card">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <div style={{ color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', fontSize: '0.8rem' }}>{title}</div>
+          <div style={{ fontSize: '2rem', fontWeight: 700, marginTop: '0.5rem' }}>{value}</div>
+          {subtitle ? <div style={{ marginTop: '0.5rem', color: '#6b7280' }}>{subtitle}</div> : null}
+        </div>
+        {accent ? <div>{accent}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+export default DataCard;

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -1,0 +1,15 @@
+function ErrorState({ message, retry }: { message: string; retry?: () => void }) {
+  return (
+    <div className="card" style={{ background: '#fef2f2', borderColor: '#fecaca' }}>
+      <h3 style={{ color: '#b91c1c' }}>문제가 발생했습니다</h3>
+      <p style={{ color: '#7f1d1d' }}>{message}</p>
+      {retry ? (
+        <button type="button" className="primary" onClick={retry}>
+          다시 시도
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export default ErrorState;

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,20 @@
+function Footer() {
+  return (
+    <footer style={{ padding: '2rem 1.5rem', background: '#111827', color: 'white', marginTop: '4rem' }}>
+      <div className="container" style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <strong>LuckyBurger7</strong>
+          <p style={{ margin: '0.5rem 0 0', color: '#9ca3af' }}>
+            고성능 버거 주문 시스템을 위한 풀스택 레퍼런스 프로젝트
+          </p>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div style={{ fontWeight: 600 }}>백엔드 API</div>
+          <p style={{ margin: '0.5rem 0 0', color: '#9ca3af' }}>Spring Boot · Redis · Spring Security · JPA</p>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+function Layout({ children }: PropsWithChildren) {
+  return (
+    <div>
+      <Navbar />
+      <main>{children}</main>
+      <Footer />
+    </div>
+  );
+}
+
+export default Layout;

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,27 @@
+function LoadingSpinner({ label = '데이터를 불러오는 중입니다...' }: { label?: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.75rem', padding: '2rem 0' }}>
+      <div
+        style={{
+          width: '3rem',
+          height: '3rem',
+          border: '4px solid #f3f4f6',
+          borderTopColor: '#f97316',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }}
+      />
+      <span style={{ color: '#6b7280', fontWeight: 500 }}>{label}</span>
+      <style>
+        {`
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `}
+      </style>
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,65 @@
+import { Link, NavLink, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const navItems = [
+  { to: '/menus', label: '메뉴' },
+  { to: '/shops', label: '매장' },
+  { to: '/coupons', label: '쿠폰' },
+  { to: '/cart', label: '장바구니' },
+  { to: '/admin', label: '관리자 대시보드' }
+];
+
+function Navbar() {
+  const { isAuthenticated, logout } = useAuth();
+  const location = useLocation();
+
+  return (
+    <header
+      style={{
+        background: 'white',
+        borderBottom: '1px solid #e5e7eb',
+        position: 'sticky',
+        top: 0,
+        zIndex: 10
+      }}
+    >
+      <div
+        className="container"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 1.5rem' }}
+      >
+        <Link to="/" style={{ fontWeight: 800, fontSize: '1.25rem', color: '#f97316' }}>
+          LuckyBurger7
+        </Link>
+        <nav style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                [
+                  'tab-button',
+                  isActive || location.pathname.startsWith(item.to) ? 'active' : undefined
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+          {isAuthenticated ? (
+            <button className="tab-button" onClick={logout} type="button">
+              로그아웃
+            </button>
+          ) : (
+            <NavLink to="/login" className={({ isActive }) => ['tab-button', isActive ? 'active' : undefined].join(' ')}>
+              로그인
+            </NavLink>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+function SectionHeader({ title, description, action }: { title: string; description?: string; action?: ReactNode }) {
+  return (
+    <div className="section-header">
+      <div>
+        <h2>{title}</h2>
+        {description ? <p style={{ color: '#6b7280', marginTop: '0.5rem' }}>{description}</p> : null}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export default SectionHeader;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,74 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import { setAuthToken } from '../api/client';
+
+type AuthContextValue = {
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const AUTH_STORAGE_KEY = 'luckyburger7_token';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(stored);
+      return typeof parsed === 'string' ? parsed : null;
+    } catch (error) {
+      console.warn('Failed to parse stored token', error);
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    setAuthToken(token);
+    if (token) {
+      localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(token));
+    } else {
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+  }, [token]);
+
+  const login = useCallback((nextToken: string) => {
+    setToken(nextToken);
+  }, []);
+
+  const logout = useCallback(() => {
+    setToken(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      token,
+      isAuthenticated: Boolean(token),
+      login,
+      logout
+    }),
+    [login, logout, token]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/index.css';
+import { AuthProvider } from './context/AuthContext';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import SectionHeader from '../components/SectionHeader';
+import DataCard from '../components/DataCard';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import {
+  fetchAdminDashboard,
+  fetchBottomShops,
+  fetchBurgerSales,
+  fetchMonthlySales,
+  fetchSideSales,
+  fetchTopShops
+} from '../api/queries';
+import { useAuth } from '../context/AuthContext';
+
+function AdminDashboardPage() {
+  const { isAuthenticated } = useAuth();
+
+  const dashboardQuery = useQuery({
+    queryKey: ['admin', 'dashboard'],
+    queryFn: fetchAdminDashboard,
+    enabled: isAuthenticated
+  });
+
+  const monthSalesQuery = useQuery({
+    queryKey: ['admin', 'sales', 'monthly'],
+    queryFn: fetchMonthlySales,
+    enabled: isAuthenticated
+  });
+
+  const topShopQuery = useQuery({
+    queryKey: ['admin', 'shops', 'top'],
+    queryFn: fetchTopShops,
+    enabled: isAuthenticated
+  });
+
+  const bottomShopQuery = useQuery({
+    queryKey: ['admin', 'shops', 'bottom'],
+    queryFn: fetchBottomShops,
+    enabled: isAuthenticated
+  });
+
+  const burgerSalesQuery = useQuery({
+    queryKey: ['admin', 'menus', 'burger'],
+    queryFn: fetchBurgerSales,
+    enabled: isAuthenticated
+  });
+
+  const sideSalesQuery = useQuery({
+    queryKey: ['admin', 'menus', 'side'],
+    queryFn: fetchSideSales,
+    enabled: isAuthenticated
+  });
+
+  const monthlyMax = useMemo(() => {
+    if (!monthSalesQuery.data || monthSalesQuery.data.length === 0) {
+      return 0;
+    }
+    return Math.max(...monthSalesQuery.data.map((item) => item.totalSales));
+  }, [monthSalesQuery.data]);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container">
+        <section>
+          <SectionHeader
+            title="관리자 대시보드"
+            description="/api/v1/admin/** 엔드포인트는 ADMIN 권한 JWT 토큰이 필요합니다"
+          />
+          <div className="alert">관리자 계정으로 로그인하면 매출 및 매장 통계를 확인할 수 있습니다.</div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader title="관리자 대시보드" description="매출 · 주문 · 쿠폰 등 핵심 지표를 집계합니다" />
+        {dashboardQuery.isLoading ? (
+          <LoadingSpinner />
+        ) : dashboardQuery.isError ? (
+          <ErrorState message={(dashboardQuery.error as Error).message} retry={dashboardQuery.refetch} />
+        ) : dashboardQuery.data ? (
+          <div className="grid grid-3">
+            <DataCard title="전체 매장" value={`${dashboardQuery.data.totalShopCount.toLocaleString()}곳`} />
+            <DataCard title="누적 주문" value={`${dashboardQuery.data.totalOrderCount.toLocaleString()}건`} />
+            <DataCard
+              title="누적 매출"
+              value={`${dashboardQuery.data.totalSales.toLocaleString()}원`}
+              subtitle={`발급된 쿠폰 ${dashboardQuery.data.activeCoupon.toLocaleString()}개`}
+            />
+          </div>
+        ) : null}
+      </section>
+
+      <section>
+        <SectionHeader title="월별 매출" description="/api/v1/admin/statistics/sales/monthly" />
+        {monthSalesQuery.isLoading ? (
+          <LoadingSpinner />
+        ) : monthSalesQuery.isError ? (
+          <ErrorState message={(monthSalesQuery.error as Error).message} retry={monthSalesQuery.refetch} />
+        ) : (
+          <div className="card" style={{ display: 'grid', gap: '1rem' }}>
+            {monthSalesQuery.data?.map((item) => {
+              const ratio = monthlyMax ? item.totalSales / monthlyMax : 0;
+              return (
+                <div key={`${item.year}-${item.month}`}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem' }}>
+                    <strong>
+                      {item.year}.{String(item.month).padStart(2, '0')}
+                    </strong>
+                    <span>{item.totalSales.toLocaleString()}원</span>
+                  </div>
+                  <div style={{ background: '#f3f4f6', borderRadius: '999px', overflow: 'hidden' }}>
+                    <div
+                      style={{
+                        width: `${Math.max(ratio * 100, 4)}%`,
+                        background: 'linear-gradient(90deg,#f97316,#fb923c)',
+                        height: '0.75rem'
+                      }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="매장 매출 TOP 10" description="/api/v1/admin/statistics/sales/shops/top10" />
+        {topShopQuery.isLoading ? (
+          <LoadingSpinner />
+        ) : topShopQuery.isError ? (
+          <ErrorState message={(topShopQuery.error as Error).message} retry={topShopQuery.refetch} />
+        ) : (
+          <div className="card" style={{ display: 'grid', gap: '0.75rem' }}>
+            {topShopQuery.data?.map((shop, index) => (
+              <div key={shop.shopId} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>
+                  #{index + 1} {shop.shopName}
+                </span>
+                <strong>{shop.totalSales.toLocaleString()}원</strong>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="매장 매출 BOTTOM 10" description="/api/v1/admin/statistics/sales/shops/bottom10" />
+        {bottomShopQuery.isLoading ? (
+          <LoadingSpinner />
+        ) : bottomShopQuery.isError ? (
+          <ErrorState message={(bottomShopQuery.error as Error).message} retry={bottomShopQuery.refetch} />
+        ) : (
+          <div className="card" style={{ display: 'grid', gap: '0.75rem' }}>
+            {bottomShopQuery.data?.map((shop, index) => (
+              <div key={shop.shopId} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>
+                  #{index + 1} {shop.shopName}
+                </span>
+                <strong>{shop.totalSales.toLocaleString()}원</strong>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="카테고리별 인기 메뉴" description="버거/사이드 매출 TOP" />
+        <div className="grid grid-3">
+          <div className="card">
+            <h3>버거</h3>
+            {burgerSalesQuery.isLoading ? (
+              <LoadingSpinner />
+            ) : burgerSalesQuery.isError ? (
+              <ErrorState message={(burgerSalesQuery.error as Error).message} retry={burgerSalesQuery.refetch} />
+            ) : (
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.5rem' }}>
+                {burgerSalesQuery.data?.map((menu, index) => (
+                  <li key={menu.menuId} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span>
+                      #{index + 1} {menu.menuName}
+                    </span>
+                    <strong>{menu.totalSales.toLocaleString()}원</strong>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="card">
+            <h3>사이드</h3>
+            {sideSalesQuery.isLoading ? (
+              <LoadingSpinner />
+            ) : sideSalesQuery.isError ? (
+              <ErrorState message={(sideSalesQuery.error as Error).message} retry={sideSalesQuery.refetch} />
+            ) : (
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: '0.5rem' }}>
+                {sideSalesQuery.data?.map((menu, index) => (
+                  <li key={menu.menuId} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span>
+                      #{index + 1} {menu.menuName}
+                    </span>
+                    <strong>{menu.totalSales.toLocaleString()}원</strong>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default AdminDashboardPage;

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import SectionHeader from '../components/SectionHeader';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import {
+  addCartMenu,
+  deleteCartMenu,
+  fetchCart,
+  updateCartMenu
+} from '../api/queries';
+import type { CartResponse } from '../api/types';
+import { useAuth } from '../context/AuthContext';
+
+function CartPage() {
+  const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuth();
+  const [useCache, setUseCache] = useState(false);
+  const [addId, setAddId] = useState('');
+  const [updatePayload, setUpdatePayload] = useState({ shopMenuId: '', quantity: 1 });
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch
+  } = useQuery<CartResponse>({
+    queryKey: ['cart', useCache],
+    queryFn: () => fetchCart(useCache),
+    enabled: isAuthenticated
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (shopMenuId: number) => addCartMenu(shopMenuId, useCache),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart', useCache] });
+      setAddId('');
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ shopMenuId, quantity }: { shopMenuId: number; quantity: number }) =>
+      updateCartMenu(shopMenuId, quantity, useCache),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart', useCache] });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (shopMenuId: number) => deleteCartMenu(shopMenuId, useCache),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart', useCache] });
+    }
+  });
+
+  const handleAdd = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const id = Number(addId);
+    if (!id || Number.isNaN(id)) return;
+    addMutation.mutate(id);
+  };
+
+  const handleUpdate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const id = Number(updatePayload.shopMenuId);
+    const quantity = Number(updatePayload.quantity);
+    if (!id || Number.isNaN(id) || quantity <= 0) return;
+    updateMutation.mutate({ shopMenuId: id, quantity });
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container">
+        <section>
+          <SectionHeader
+            title="장바구니"
+            description="/api/v1/user/carts 및 /api/v2/user/carts API는 인증 토큰이 필요합니다"
+          />
+          <div className="alert">먼저 로그인하여 JWT 액세스 토큰을 발급받은 뒤 이용해 주세요.</div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader
+          title="장바구니"
+          description={useCache ? 'Redis 캐시 버전(v2) API를 호출합니다' : 'RDB 기반 기본(v1) API를 호출합니다'}
+          action={
+            <button type="button" className="tab-button" onClick={() => setUseCache((prev) => !prev)}>
+              {useCache ? 'v1 호출로 전환' : 'v2 호출로 전환'}
+            </button>
+          }
+        />
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : isError ? (
+          <ErrorState message={(error as Error).message} retry={refetch} />
+        ) : (
+          <div className="card">
+            <h3>총 금액</h3>
+            <div style={{ fontSize: '2rem', fontWeight: 700 }}>{data?.totalPrice.toLocaleString()}원</div>
+            <div style={{ marginTop: '1.5rem', display: 'grid', gap: '1rem' }}>
+              {data?.cartMenus.map((item) => (
+                <div key={item.shopMenuId} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <div style={{ fontWeight: 600 }}>{item.menuName}</div>
+                    <div style={{ color: '#6b7280', fontSize: '0.9rem' }}>{item.shopName}</div>
+                    <div style={{ marginTop: '0.25rem' }}>{item.price.toLocaleString()}원 × {item.quantity}</div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                    <button
+                      type="button"
+                      className="tab-button"
+                      onClick={() => deleteMutation.mutate(item.shopMenuId)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="메뉴 추가" description="/api/v1/user/carts POST" />
+        <form onSubmit={handleAdd} className="card" style={{ display: 'grid', gap: '1rem' }}>
+          <label>
+            <span>Shop Menu ID</span>
+            <input value={addId} onChange={(event) => setAddId(event.target.value)} placeholder="숫자 ID" />
+          </label>
+          <button type="submit" className="primary" disabled={addMutation.isPending}>
+            장바구니에 추가
+          </button>
+          {addMutation.error ? <div className="alert">{(addMutation.error as Error).message}</div> : null}
+        </form>
+      </section>
+
+      <section>
+        <SectionHeader title="수량 변경" description="/api/v1/user/carts PUT" />
+        <form onSubmit={handleUpdate} className="card" style={{ display: 'grid', gap: '1rem' }}>
+          <label>
+            <span>Shop Menu ID</span>
+            <input
+              value={updatePayload.shopMenuId}
+              onChange={(event) => setUpdatePayload((prev) => ({ ...prev, shopMenuId: event.target.value }))}
+              placeholder="숫자 ID"
+            />
+          </label>
+          <label>
+            <span>수량</span>
+            <input
+              type="number"
+              min={1}
+              value={updatePayload.quantity}
+              onChange={(event) => setUpdatePayload((prev) => ({ ...prev, quantity: Number(event.target.value) }))}
+            />
+          </label>
+          <button type="submit" className="primary" disabled={updateMutation.isPending}>
+            수량 업데이트
+          </button>
+          {updateMutation.error ? <div className="alert">{(updateMutation.error as Error).message}</div> : null}
+        </form>
+      </section>
+    </div>
+  );
+}
+
+export default CartPage;

--- a/frontend/src/pages/Coupons.tsx
+++ b/frontend/src/pages/Coupons.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import SectionHeader from '../components/SectionHeader';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import { fetchCoupons } from '../api/queries';
+import type { CouponResponse } from '../api/types';
+
+function formatCoupon(coupon: CouponResponse) {
+  if (coupon.couponType === 'RATIO') {
+    return `${coupon.discount}% 할인`;
+  }
+  return `${coupon.discount.toLocaleString()}원 할인`;
+}
+
+function CouponsPage() {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
+    queryKey: ['coupons', page],
+    queryFn: () => fetchCoupons(page, 12),
+    keepPreviousData: true
+  });
+
+  const hasNext = useMemo(() => (data ? data.page + 1 < data.totalPages : false), [data]);
+  const hasPrev = page > 0;
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader
+          title="LuckyBurger7 쿠폰"
+          description="/api/v1/coupons API로부터 전체 쿠폰 리스트를 받아옵니다"
+        />
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : isError ? (
+          <ErrorState message={(error as Error).message} retry={refetch} />
+        ) : (
+          <>
+            <div className="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>쿠폰명</th>
+                    <th>혜택</th>
+                    <th>남은 수량</th>
+                    <th>유효기간</th>
+                    <th>생성일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data?.data.map((coupon) => (
+                    <tr key={coupon.couponId}>
+                      <td>{coupon.couponId}</td>
+                      <td>{coupon.name}</td>
+                      <td>{formatCoupon(coupon)}</td>
+                      <td>{coupon.count}</td>
+                      <td>{new Date(coupon.expirationDate).toLocaleDateString()}</td>
+                      <td>{new Date(coupon.createAt).toLocaleDateString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2rem' }}>
+              <button type="button" className="tab-button" disabled={!hasPrev || isFetching} onClick={() => setPage((prev) => prev - 1)}>
+                ← 이전
+              </button>
+              <div style={{ color: '#6b7280' }}>
+                {data ? data.page + 1 : 0} / {data?.totalPages ?? 0}
+              </div>
+              <button type="button" className="tab-button" disabled={!hasNext || isFetching} onClick={() => setPage((prev) => prev + 1)}>
+                다음 →
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default CouponsPage;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,182 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import SectionHeader from '../components/SectionHeader';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import DataCard from '../components/DataCard';
+import { fetchMenus, fetchCoupons, fetchShops } from '../api/queries';
+import type { MenuResponse } from '../api/types';
+
+const MENU_LABEL: Record<MenuResponse['menuCategory'], string> = {
+  HAMBURGER: '버거',
+  SIDE: '사이드',
+  DRINK: '음료'
+};
+
+function HomePage() {
+  const {
+    data: menuPage,
+    isLoading: isMenuLoading,
+    isError: isMenuError,
+    error: menuError,
+    refetch: refetchMenu
+  } = useQuery({
+    queryKey: ['menus', 'home'],
+    queryFn: () => fetchMenus({ page: 0, size: 6 })
+  });
+
+  const {
+    data: couponPage,
+    isLoading: isCouponLoading,
+    isError: isCouponError,
+    error: couponError,
+    refetch: refetchCoupons
+  } = useQuery({
+    queryKey: ['coupons', 'home'],
+    queryFn: () => fetchCoupons(0, 4)
+  });
+
+  const {
+    data: shopPage,
+    isLoading: isShopLoading,
+    isError: isShopError,
+    error: shopError,
+    refetch: refetchShops
+  } = useQuery({
+    queryKey: ['shops', 'home'],
+    queryFn: () => fetchShops({ page: 0, size: 4 })
+  });
+
+  return (
+    <div className="container">
+      <section className="hero">
+        <div>
+          <span className="badge">LuckyBurger7 Platform</span>
+          <h1>
+            고성능 버거 주문 & 통계 플랫폼
+            <br /> 프론트엔드 대시보드
+          </h1>
+          <p>
+            Spring Boot 백엔드가 제공하는 다양한 API를 탐색하고, 매장 · 메뉴 · 쿠폰 · 장바구니 기능을 하나의
+            프론트에서 빠르게 테스트해 보세요.
+          </p>
+          <div style={{ display: 'flex', gap: '1rem', marginTop: '2rem', flexWrap: 'wrap' }}>
+            <Link to="/menus">
+              <button type="button" className="primary">
+                전체 메뉴 보기
+              </button>
+            </Link>
+            <Link to="/admin" style={{ color: '#f97316', fontWeight: 600 }}>
+              관리자 지표 살펴보기 →
+            </Link>
+          </div>
+        </div>
+        <div>
+          <div
+            style={{
+              background: 'linear-gradient(135deg, #f97316, #ea580c)',
+              borderRadius: '1.5rem',
+              padding: '3rem',
+              color: 'white',
+              boxShadow: '0 40px 70px -50px rgba(249, 115, 22, 0.8)'
+            }}
+          >
+            <h2 style={{ margin: 0 }}>Lucky Insights</h2>
+            <p style={{ color: 'rgba(255,255,255,0.8)' }}>
+              실시간 통계와 버거 매장의 성장을 위한 핵심 데이터를 시각화합니다.
+            </p>
+            <ul style={{ listStyle: 'none', margin: '2rem 0 0', padding: 0, display: 'grid', gap: '1rem' }}>
+              <li>✅ 전국 매장 재고 및 영업상태 파악</li>
+              <li>✅ 인기 메뉴/쿠폰 실적 추적</li>
+              <li>✅ 주문 처리량 및 매출 추세 분석</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="API 요약" description="LuckyBurger7 백엔드에서 제공하는 주요 엔드포인트" />
+        <div className="grid grid-3">
+          <DataCard
+            title="메뉴"
+            value={`${menuPage?.totalElements ?? 0} 개`}
+            subtitle="카테고리별 판매 메뉴를 조회하고 검색하세요"
+          />
+          <DataCard title="매장" value={`${shopPage?.totalElements ?? 0} 개`} subtitle="전국 LuckyBurger 매장을 탐색" />
+          <DataCard
+            title="쿠폰"
+            value={`${couponPage?.totalElements ?? 0} 종`}
+            subtitle="발급 가능한 프로모션 현황"
+          />
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="추천 메뉴" description="최근 등록된 인기 메뉴를 빠르게 확인하세요" />
+        {isMenuLoading ? (
+          <LoadingSpinner />
+        ) : isMenuError ? (
+          <ErrorState message={(menuError as Error).message} retry={refetchMenu} />
+        ) : (
+          <div className="grid grid-3">
+            {menuPage?.data.map((menu) => (
+              <div key={menu.menuId} className="card">
+                <h3>{menu.name}</h3>
+                <p style={{ color: '#6b7280' }}>{MENU_LABEL[menu.menuCategory]}</p>
+                <div style={{ fontWeight: 700, fontSize: '1.25rem' }}>{menu.price.toLocaleString()}원</div>
+                <Link to={`/menus?menuId=${menu.menuId}`} style={{ color: '#f97316', fontWeight: 600 }}>
+                  자세히 보기 →
+                </Link>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="가까운 매장" description="LuckyBurger7에서 운영 중인 매장을 검색해 보세요" />
+        {isShopLoading ? (
+          <LoadingSpinner />
+        ) : isShopError ? (
+          <ErrorState message={(shopError as Error).message} retry={refetchShops} />
+        ) : (
+          <div className="grid grid-3">
+            {shopPage?.data.map((shop) => (
+              <div key={shop.shopId} className="card">
+                <h3>{shop.name}</h3>
+                <p style={{ color: '#6b7280' }}>{shop.address}</p>
+                <span className={`status-${shop.businessStatus.toLowerCase()}`}>{shop.businessStatus}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <SectionHeader title="이달의 쿠폰" description="할인 혜택을 놓치지 마세요" />
+        {isCouponLoading ? (
+          <LoadingSpinner />
+        ) : isCouponError ? (
+          <ErrorState message={(couponError as Error).message} retry={refetchCoupons} />
+        ) : (
+          <div className="grid grid-3">
+            {couponPage?.data.map((coupon) => (
+              <div key={coupon.couponId} className="card">
+                <h3>{coupon.name}</h3>
+                <p style={{ color: '#6b7280' }}>{coupon.couponType}</p>
+                <div style={{ fontWeight: 700, fontSize: '1.1rem' }}>
+                  할인율 {coupon.discount}% · 재고 {coupon.count}개
+                </div>
+                <div style={{ marginTop: '0.5rem', color: '#9ca3af' }}>
+                  {new Date(coupon.expirationDate).toLocaleDateString()}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import SectionHeader from '../components/SectionHeader';
+import { authenticate } from '../api/queries';
+import { useAuth } from '../context/AuthContext';
+
+function LoginPage() {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [form, setForm] = useState({ email: '', password: '' });
+
+  const mutation = useMutation({
+    mutationFn: () => authenticate(form),
+    onSuccess: (token) => {
+      login(token.accessToken);
+      navigate('/');
+    }
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    mutation.mutate();
+  };
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader
+          title="로그인"
+          description="/api/v1/login API를 통해 JWT 액세스 토큰을 발급받습니다"
+        />
+        <form onSubmit={handleSubmit} className="card" style={{ display: 'grid', gap: '1rem', maxWidth: '420px' }}>
+          <label>
+            <span>이메일</span>
+            <input
+              type="email"
+              value={form.email}
+              onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+              required
+            />
+          </label>
+          <label>
+            <span>비밀번호</span>
+            <input
+              type="password"
+              value={form.password}
+              onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+              required
+            />
+          </label>
+          <button type="submit" className="primary" disabled={mutation.isPending}>
+            로그인
+          </button>
+          {mutation.error ? <div className="alert">{(mutation.error as Error).message}</div> : null}
+          <p style={{ color: '#6b7280', fontSize: '0.9rem' }}>
+            관리자 통계(/api/v1/admin/...)를 호출하려면 ADMIN 권한 계정으로 로그인해야 합니다.
+          </p>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/frontend/src/pages/Menus.tsx
+++ b/frontend/src/pages/Menus.tsx
@@ -1,0 +1,112 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
+import SectionHeader from '../components/SectionHeader';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import { fetchMenus } from '../api/queries';
+import type { MenuResponse } from '../api/types';
+
+const CATEGORY_LABEL: Record<MenuResponse['menuCategory'], string> = {
+  HAMBURGER: '버거',
+  SIDE: '사이드',
+  DRINK: '음료'
+};
+
+function MenusPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [page, setPage] = useState(() => Number(searchParams.get('page') ?? 0));
+  const [keyword, setKeyword] = useState(searchParams.get('menuName') ?? '');
+
+  const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
+    queryKey: ['menus', page, keyword],
+    queryFn: () => fetchMenus({ page, size: 12, keyword: keyword || undefined }),
+    keepPreviousData: true
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const value = (formData.get('keyword') as string).trim();
+    setPage(0);
+    setKeyword(value);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set('menuName', value);
+      } else {
+        next.delete('menuName');
+      }
+      next.set('page', '0');
+      return next;
+    });
+  };
+
+  const hasNext = useMemo(() => (data ? data.page + 1 < data.totalPages : false), [data]);
+  const hasPrev = page > 0;
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('page', String(nextPage));
+      return next;
+    });
+  };
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader
+          title="LuckyBurger7 메뉴"
+          description="백엔드의 /api/v1/menus API와 검색 엔드포인트를 활용합니다"
+        />
+        <form
+          onSubmit={handleSubmit}
+          style={{ display: 'flex', gap: '1rem', marginBottom: '1.5rem', alignItems: 'center', flexWrap: 'wrap' }}
+        >
+          <input
+            name="keyword"
+            placeholder="메뉴 이름으로 검색"
+            defaultValue={keyword}
+            style={{ flex: '1 1 260px' }}
+          />
+          <button type="submit" className="primary" disabled={isFetching}>
+            검색
+          </button>
+        </form>
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : isError ? (
+          <ErrorState message={(error as Error).message} retry={refetch} />
+        ) : (
+          <>
+            <div className="grid grid-3">
+              {data?.data.map((menu) => (
+                <div key={menu.menuId} className="card">
+                  <h3>{menu.name}</h3>
+                  <p style={{ color: '#6b7280' }}>{CATEGORY_LABEL[menu.menuCategory]}</p>
+                  <div style={{ fontWeight: 700, fontSize: '1.25rem' }}>{menu.price.toLocaleString()}원</div>
+                  <p style={{ marginTop: '0.5rem', color: '#9ca3af' }}>ID: {menu.menuId}</p>
+                </div>
+              ))}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2rem' }}>
+              <button type="button" className="tab-button" disabled={!hasPrev || isFetching} onClick={() => handlePageChange(page - 1)}>
+                ← 이전
+              </button>
+              <div style={{ color: '#6b7280' }}>
+                {data ? data.page + 1 : 0} / {data?.totalPages ?? 0}
+              </div>
+              <button type="button" className="tab-button" disabled={!hasNext || isFetching} onClick={() => handlePageChange(page + 1)}>
+                다음 →
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default MenusPage;

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+function NotFoundPage() {
+  return (
+    <div className="container" style={{ textAlign: 'center', padding: '4rem 0' }}>
+      <div className="card" style={{ display: 'inline-block', padding: '3rem 4rem' }}>
+        <h1 style={{ fontSize: '3rem', margin: 0, color: '#f97316' }}>404</h1>
+        <p style={{ color: '#6b7280' }}>요청하신 페이지를 찾을 수 없습니다.</p>
+        <Link to="/" style={{ color: '#f97316', fontWeight: 600 }}>
+          홈으로 돌아가기 →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/frontend/src/pages/Shops.tsx
+++ b/frontend/src/pages/Shops.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import SectionHeader from '../components/SectionHeader';
+import LoadingSpinner from '../components/LoadingSpinner';
+import ErrorState from '../components/ErrorState';
+import { fetchShops, fetchShopMenus } from '../api/queries';
+import type { BusinessStatus, ShopMenuResponse } from '../api/types';
+import type { ApiPageResponse } from '../api/client';
+
+const STATUS_LABEL: Record<BusinessStatus, string> = {
+  OPEN: '영업중',
+  BREAK: '브레이크 타임',
+  CLOSED: '영업종료'
+};
+
+const STATUS_CLASS: Record<BusinessStatus, string> = {
+  OPEN: 'status-open',
+  BREAK: 'status-break',
+  CLOSED: 'status-closed'
+};
+
+const MENU_CATEGORY_LABEL: Record<ShopMenuResponse['menuCategory'], string> = {
+  HAMBURGER: '버거',
+  SIDE: '사이드',
+  DRINK: '음료'
+};
+
+function ShopsPage() {
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(0);
+  const [selectedShop, setSelectedShop] = useState<number | null>(null);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching
+  } = useQuery({
+    queryKey: ['shops', page, keyword],
+    queryFn: () => fetchShops({ page, size: 10, keyword: keyword || undefined }),
+    keepPreviousData: true
+  });
+
+  const {
+    data: menuPage,
+    isFetching: isMenuFetching,
+    error: menuError,
+    refetch: refetchMenus
+  } = useQuery<ApiPageResponse<ShopMenuResponse>>({
+    queryKey: ['shopMenus', selectedShop],
+    queryFn: () => fetchShopMenus(selectedShop!, 0, 6),
+    enabled: selectedShop !== null
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setKeyword((formData.get('keyword') as string).trim());
+    setPage(0);
+  };
+
+  const hasNext = useMemo(() => (data ? data.page + 1 < data.totalPages : false), [data]);
+  const hasPrev = page > 0;
+
+  return (
+    <div className="container">
+      <section>
+        <SectionHeader
+          title="LuckyBurger7 매장"
+          description="/api/v1/shops/search 및 매장별 메뉴 조회 엔드포인트를 연결했습니다"
+        />
+        <form
+          onSubmit={handleSubmit}
+          style={{ display: 'flex', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap', alignItems: 'center' }}
+        >
+          <input
+            name="keyword"
+            placeholder="매장 이름으로 검색"
+            defaultValue={keyword}
+            style={{ flex: '1 1 260px' }}
+          />
+          <button type="submit" className="primary" disabled={isFetching}>
+            검색
+          </button>
+        </form>
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : isError ? (
+          <ErrorState message={(error as Error).message} retry={refetch} />
+        ) : (
+          <>
+            <div className="grid grid-3">
+              {data?.data.map((shop) => (
+                <div key={shop.shopId} className="card">
+                  <h3>{shop.name}</h3>
+                  <p style={{ color: '#6b7280' }}>{shop.address}</p>
+                  <div className={STATUS_CLASS[shop.businessStatus]}>{STATUS_LABEL[shop.businessStatus]}</div>
+                  <button
+                    type="button"
+                    className="tab-button"
+                    style={{ marginTop: '1rem' }}
+                    onClick={() => setSelectedShop(shop.shopId)}
+                  >
+                    메뉴 보기
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2rem' }}>
+              <button type="button" className="tab-button" disabled={!hasPrev || isFetching} onClick={() => setPage((prev) => prev - 1)}>
+                ← 이전
+              </button>
+              <div style={{ color: '#6b7280' }}>
+                {data ? data.page + 1 : 0} / {data?.totalPages ?? 0}
+              </div>
+              <button type="button" className="tab-button" disabled={!hasNext || isFetching} onClick={() => setPage((prev) => prev + 1)}>
+                다음 →
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+
+      {selectedShop ? (
+        <section>
+          <SectionHeader
+            title={`선택한 매장 (#${selectedShop}) 메뉴`}
+            description="/api/v1/shops/{shopId}/shopMenus 응답을 보여줍니다"
+            action={
+              <button type="button" className="tab-button" onClick={() => setSelectedShop(null)}>
+                닫기
+              </button>
+            }
+          />
+          {isMenuFetching ? (
+            <LoadingSpinner />
+          ) : menuError ? (
+            <ErrorState message={(menuError as Error).message} retry={refetchMenus} />
+          ) : (
+            <div className="grid grid-3">
+              {menuPage?.data.map((menu: ShopMenuResponse) => (
+                <div key={menu.shopMenuId} className="card">
+                  <h3>{menu.name}</h3>
+                  <p style={{ color: '#6b7280' }}>{MENU_CATEGORY_LABEL[menu.menuCategory]}</p>
+                  <div style={{ fontWeight: 700 }}>{menu.price.toLocaleString()}원</div>
+                  <span style={{ color: '#f97316', fontWeight: 600 }}>{menu.menuStatus}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+export default ShopsPage;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,0 +1,218 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Pretendard', 'Noto Sans KR', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #111827;
+  background-color: #f3f4f6;
+  --primary: #f97316;
+  --primary-dark: #ea580c;
+  --surface: #ffffff;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+main {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+button {
+  font: inherit;
+}
+
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+section {
+  margin-bottom: 3rem;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 30px -24px rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--border);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.75rem;
+  background-color: #fef3c7;
+  border-radius: 999px;
+  color: #92400e;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2);
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.2s ease;
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f9fafb;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.status-open {
+  color: #15803d;
+  font-weight: 600;
+}
+
+.status-break {
+  color: #ca8a04;
+  font-weight: 600;
+}
+
+.status-closed {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+  margin-bottom: 3rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  color: var(--muted);
+}
+
+.hero img {
+  width: 100%;
+  border-radius: 1.5rem;
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.5);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+.tab-group {
+  display: inline-flex;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+}
+
+.tab-button {
+  border: none;
+  background: transparent;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.tab-button.active {
+  background: white;
+  color: #111827;
+  box-shadow: 0 6px 12px -8px rgba(15, 23, 42, 0.4);
+}
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid #fcd34d;
+  background: #fef9c3;
+  color: #92400e;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react()],
+    server: {
+      port: Number(env.VITE_DEV_SERVER_PORT ?? 5173),
+      proxy: env.VITE_API_PROXY
+        ? {
+            '/api': {
+              target: env.VITE_API_PROXY,
+              changeOrigin: true,
+              secure: false
+            }
+          }
+        : undefined
+    }
+  };
+});


### PR DESCRIPTION
## Summary
- scaffold a new Vite + React (TypeScript) app under `frontend/` to surface LuckyBurger7 APIs
- implement pages for menus, shops, coupons, carts, and admin dashboards with shared layout, auth context, and API client
- document frontend setup, environment variables, and key screens in the root README

## Testing
- not run (node dependencies not installed in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d3db0ba1c832bb740bd6bcb3d4ce0)