### PR TITLE
feat/ swaggerconfig 로그인 보안키 헤더로 저장 추가

### DIFF
--- a/src/main/java/org/example/luckyburger/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/luckyburger/common/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package org.example.luckyburger.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,10 +13,24 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        //Api 호출에 적용할 요구사항
+        SecurityRequirement accessTokenRequirement = new SecurityRequirement().addList("accessToken");
+
         return new OpenAPI()
                 .info(new Info()
                         .title("LuckyBurger API 문서")
                         .description("럭키버거 백엔드 REST API 명세서입니다.")
-                        .version("v2"));
+                        .version("v2"))
+                .components(
+                        new Components()
+                                .addSecuritySchemes("accessToken",
+                                        new SecurityScheme()
+                                                .name("accessToken")
+                                                .type(SecurityScheme.Type.APIKEY)
+                                                .in(SecurityScheme.In.HEADER)
+                                                .bearerFormat("JWT")
+                                )
+                )
+                .addSecurityItem(accessTokenRequirement);
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**

Related to: #17, #20

## 📝 **작업 내용**

swagger 사용시 로그인시 사용자 토큰을 저장가능하게 바꾸었습니다.