### PR TITLE
feat : caffeine 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
 
     // [swagger]
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // [Caffeine]
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/luckyburger/common/config/CacheConfig.java
+++ b/src/main/java/org/example/luckyburger/common/config/CacheConfig.java
@@ -4,6 +4,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,6 +19,7 @@ import java.time.Duration;
 public class CacheConfig {
 
     @Bean
+    @Primary
     public CacheManager cacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))

--- a/src/main/java/org/example/luckyburger/common/config/LocalCacheConfig.java
+++ b/src/main/java/org/example/luckyburger/common/config/LocalCacheConfig.java
@@ -1,0 +1,63 @@
+package org.example.luckyburger.common.config;
+
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class LocalCacheConfig {
+
+    //Caffeine 설정
+    @Bean
+    public Caffeine<Object, Object> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .initialCapacity(100)
+                .maximumSize(1000)
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .expireAfterAccess(2, TimeUnit.MINUTES)
+                .recordStats(); // 통계
+    }
+
+    //CacheManager 등록
+    @Bean(name = "caffeineCacheManager")
+    public CacheManager caffeineCacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+
+        Cache menuCache = new CaffeineCache("menuCache",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(2, TimeUnit.HOURS)
+                        .maximumSize(1000)
+                        .build(), false);
+
+        Cache eventCache = new CaffeineCache("eventCache",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(2, TimeUnit.HOURS)
+                        .maximumSize(1000)
+                        .build(), false);
+
+        Cache shopCache = new CaffeineCache("shopCache",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(2, TimeUnit.HOURS)
+                        .maximumSize(1000)
+                        .build(), false);
+
+        Cache statisticCache = new CaffeineCache("statisticCache",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(6, TimeUnit.HOURS)
+                        .maximumSize(1000)
+                        .build(), false);
+
+        cacheManager.setCaches(List.of(menuCache, eventCache, shopCache, statisticCache));
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/example/luckyburger/domain/shop/controller/ShopController.java
+++ b/src/main/java/org/example/luckyburger/domain/shop/controller/ShopController.java
@@ -4,9 +4,11 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.example.luckyburger.common.dto.response.ApiPageResponse;
 import org.example.luckyburger.common.dto.response.ApiResponse;
+import org.example.luckyburger.domain.menu.dto.response.MenuResponse;
 import org.example.luckyburger.domain.shop.dto.response.ShopMenuResponse;
 import org.example.luckyburger.domain.shop.dto.response.ShopResponse;
 import org.example.luckyburger.domain.shop.service.ShopService;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -53,4 +55,14 @@ public class ShopController {
         return ApiResponse.success(shopService.getMenuDetail(shopId, shopMenuId));
     }
 
+    @GetMapping("/v1/shops")
+    public ResponseEntity<ApiPageResponse<ShopResponse>> getAllShop(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        Pageable pageable = PageRequest.of(page,size);
+        Page<ShopResponse> responses = shopService.getAllShopResponse(pageable);
+        return ApiPageResponse.success(responses);
+
+    }
 }

--- a/src/main/java/org/example/luckyburger/domain/shop/service/ShopService.java
+++ b/src/main/java/org/example/luckyburger/domain/shop/service/ShopService.java
@@ -2,6 +2,7 @@ package org.example.luckyburger.domain.shop.service;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.example.luckyburger.domain.menu.entity.Menu;
 import org.example.luckyburger.domain.shop.dto.response.ShopMenuResponse;
 import org.example.luckyburger.domain.shop.dto.response.ShopResponse;
 import org.example.luckyburger.domain.shop.entity.Shop;
@@ -48,5 +49,10 @@ public class ShopService {
         }
 
         return ShopMenuResponse.from(shopMenu);
+    }
+
+    public Page<ShopResponse> getAllShopResponse(Pageable pageable){
+        Page<Shop> shops = shopRepository.findAll(pageable);
+        return shops.map(ShopResponse::from);
     }
 }

--- a/src/main/java/org/example/luckyburger/domain/statistic/service/StatisticService.java
+++ b/src/main/java/org/example/luckyburger/domain/statistic/service/StatisticService.java
@@ -12,6 +12,9 @@ import org.example.luckyburger.domain.statistic.dto.response.AdminDashboardRespo
 import org.example.luckyburger.domain.statistic.dto.response.MenuTotalSalesResponse;
 import org.example.luckyburger.domain.statistic.dto.response.MonthTotalSalesResponse;
 import org.example.luckyburger.domain.statistic.dto.response.ShopTotalSalesResponse;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Transactional(readOnly = true)
+@CacheConfig(cacheManager = "caffeineCacheManager")
 public class StatisticService {
 
     private final OrderEntityFinder orderEntityFinder;
@@ -33,16 +37,19 @@ public class StatisticService {
         return orderEntityFinder.getAllMonthTotalSalesResponse();
     }
 
+    @Cacheable(value = "statisticCache", sync = true)
     public List<ShopTotalSalesResponse> getTopTenShopTotalSalesResponse() {
 
         return orderEntityFinder.getAllShopTotalSalesResponseOrderByDesc();
     }
 
+    @Cacheable(value = "statisticCache", sync = true)
     public List<ShopTotalSalesResponse> getBottomTenShopTotalSalesResponse() {
 
         return orderEntityFinder.getAllShopTotalSalesResponseOrderByAsc();
     }
 
+    @Cacheable(value = "statisticCache", sync = true)
     public List<MenuTotalSalesResponse> getMenuTotalSalesResponse(MenuCategory category) {
 
         List<Long> categoryMenuIds = menuEntityFinder.getAllMenuIdByCategory(category);


### PR DESCRIPTION
caffeine 캐시를 적용했습니다.
기존 레디스 캐시와 충돌을 피하기 위해 레디스 캐시 config에는 primary를 걸어서 기본적으로 레디스 캐시를 사용하되 caffeine이 명시된 곳에만 caffeine 캐시가 사용되도록 했습니다.

또한 피그마 상에 있는 상점 모두보기 페이지가 없는 것 같아서 해당 메서드를 구현했습니다.

## 🔗 **연관된 이슈**

Related to: #17, #20

## 📝 **작업 내용**

- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등